### PR TITLE
Update actions to latest because of Node 20 deprecation in actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,11 +17,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.ref }}
         fetch-depth: ${{ inputs.fetch-depth }}
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
     - name: Enable corepack


### PR DESCRIPTION
Node 20 actions are deprecated, this PR just updates the other actions used to the latest versions that use Node 24 instead.